### PR TITLE
commented out line causing compile error

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1763,7 +1763,7 @@ void StartNode(boost::thread_group& threadGroup)
     threadGroup.create_thread(boost::bind(&LoopForever<void (*)()>, "updatebids", &getbids, UPDATE_BID_INTERVAL * 1000));
 
     // Dump Miners 
-    threadGroup.create_thread(boost::bind(&LoopForever<void (*)()>, "banknodedump", &miningbanknodelist, DUMP_BN_INTERVAL * 1000));
+    //threadGroup.create_thread(boost::bind(&LoopForever<void (*)()>, "banknodedump", &miningbanknodelist, DUMP_BN_INTERVAL * 1000));
 }
 
 bool StopNode()


### PR DESCRIPTION
Compiling with this line uncommented doesn't work for me - it complains about &miningbanknodelist. Also this line appears to try to create a thread "banknodedump" that is a duplicate name from the "// Dump Banknodes" block above.